### PR TITLE
Inclusão de pacotes para construção do Pillow

### DIFF
--- a/apt-requirements
+++ b/apt-requirements
@@ -1,5 +1,7 @@
 ##### Dependências Odoo #####
+gcc
 python-pip
+python-dev
 libxml2-dev
 libxslt-dev
 libevent-dev

--- a/install_odoo_trustcodebr.sh
+++ b/install_odoo_trustcodebr.sh
@@ -1,30 +1,39 @@
 #! /bin/bash
 
-echo "Esse script é focado na instalação do odoo V.10"
+ODOO_VERSION='10'
+
+echo "Esse script é focado na instalação do odoo V.$ODOO_VERSION"
 echo "com o foco em desenvolvimento."
 
 echo "Atualizando cache do sistema"
 sudo apt-get update
+
 echo "Instalando git"
 sudo apt-get install git -y
+echo "Pacote git instalado"
 
-echo "instalando PostgresSql"
+echo "Instalando postgresql"
 sudo apt install postgresql -y
-echo "Instalação do PostgresSql completa"
+echo "Pacote postgreql instalado"
 
-echo "Instalando pgAdmin"
+echo "Instalando pgadmin"
 sudo apt install pgadmin3 -y
 echo "pgAdmin instalado"
 
-echo "Criar usuário."
+echo "Instalando python-dev"
+sudo apt install python-dev -y
+echo "Pacote python-dev instalado"
+
+echo "Instalando gcc"
+sudo apt install gcc -y
+echo "Pacote gcc instalado"
+
+echo "Criando usuário postgreSQL ..."
 sudo -u postgres -- psql -c "ALTER USER postgres WITH PASSWORD '123';"
 sudo -u postgres -- psql -c "DROP ROLE odoo;"
 sudo -u postgres -- psql -c "CREATE ROLE odoo LOGIN ENCRYPTED PASSWORD 'md5f7b7bca97b76afe46de6631ff9f7175c' NOSUPERUSER INHERIT CREATEDB CREATEROLE REPLICATION"
-echo "Usuário odoo criado. Senha = '123'"
-echo "usuário postgress agora tem a senha= '123'"
 
-
-echo "Instalando ##### Dependências Odoo #####"
+echo "==== Instalando dependências Odoo ===="
 sudo apt-get install --no-install-recommends python-pip -y
 sudo apt-get install --no-install-recommends libxml2-dev -y
 sudo apt-get install --no-install-recommends libxslt-dev -y
@@ -35,14 +44,17 @@ sudo apt-get install --no-install-recommends libjpeg-dev -y
 sudo apt-get install --no-install-recommends nodejs -y
 sudo apt-get install --no-install-recommends npm -y
 sudo apt-get install node-less -y
+sudo npm install -g less
+sudo ln -s /usr/bin/nodejs /usr/bin/node
 
-echo "instalando ##### Dependências da Localização Brasileira #####"
+
+echo "==== Instalando dependências da Localização Brasileira ===="
 sudo apt-get install --no-install-recommends python-libxml2 -y
 sudo apt-get install --no-install-recommends libxmlsec1-dev -y
 sudo apt-get install --no-install-recommends python-openssl -y
 sudo apt-get install --no-install-recommends python-cffi -y
- 
-echo "##### Dependências do WKHTMLTOX #####"
+
+echo "==== Instalando dependências do WKHTMLTOX ===="
 sudo apt-get install --no-install-recommends zlib1g-dev -y
 sudo apt-get install --no-install-recommends fontconfig -y
 sudo apt-get install --no-install-recommends libfreetype6 -y
@@ -51,8 +63,10 @@ sudo apt-get install --no-install-recommends libxext6 -y
 sudo apt-get install --no-install-recommends libxrender1 -y
 sudo apt-get install --no-install-recommends libjpeg-turbo8 -y
 
+wget http://download.gna.org/wkhtmltopdf/0.12/0.12.1/wkhtmltox-0.12.1_linux-trusty-amd64.deb -P ~/
+sudo dpkg -i ~/wkhtmltox-0.12.1_linux-trusty-amd64.deb
 
-Echo "Instalação das dependências pip"
+echo "==== Instalação dependências pip para os módulos ===="
 sudo -H pip install --upgrade pip
 sudo -H pip install --upgrade setuptools
 sudo -H pip install Babel==1.3
@@ -104,17 +118,17 @@ sudo -H pip install pytrustnfe
 sudo -H pip install python-boleto
 sudo -H pip install python-cnab
 sudo -H pip install http://labs.libre-entreprise.org/frs/download.php/897/pyxmlsec-0.3.1.tar.gz
-echo "pip e seus requerimentos estão instalados."
+echo ">>> pip e seus requerimentos estão instalados. <<<"
 
-echo "clonando repositório git do odoo. Isso pode demorar um bom tempo."
-echo "se sua internet é lenta, recomenda-se tomar um café enquanto aguarda."
-git clone https://github.com/odoo/odoo.git
-
+echo "Clonando repositório oficial Odoo no GitHub. Isso pode demorar um bom tempo."
+echo "Se sua internet é lenta, recomenda-se tomar um café enquanto aguarda."
+git clone https://github.com/odoo/odoo.git ~/odoo
 
 echo "Terminando o arquivo de configuração, quase lá."
 rm ~/odoo/odoo-config
+echo ""
 echo "[options]" >> ~/odoo/odoo-config
-echo "addons_path=addons,odoo/addons,~/odoo-brasil" >> ~/odoo/odoo-config
+echo "addons_path = addons,odoo/addons,~/odoo-brasil" >> ~/odoo/odoo-config
 echo "admin_passwd = admin" >> ~/odoo/odoo-config
 echo "auto_reload = False" >> ~/odoo/odoo-config
 echo "csv_internal_sep = ," >> ~/odoo/odoo-config
@@ -124,6 +138,19 @@ echo "db_name = False" >> ~/odoo/odoo-config
 echo "db_port = False" >> ~/odoo/odoo-config
 echo "db_template = template0" >> ~/odoo/odoo-config
 echo "db_user = odoo" >> ~/odoo/odoo-config
-echo "db_password= 123" >> ~/odoo/odoo-config
+echo "db_password = 123" >> ~/odoo/odoo-config
 
-git clone https://github.com/Trust-Code/odoo-brasil.git
+echo "Clonando repositório oficial dos módulos Odoo Brasil no GitHub."
+echo "Agora falta pouco."
+git clone https://github.com/Trust-Code/odoo-brasil.git ~/odoo-brasil
+
+echo "==== Instalação e configuração Odoo Brasil completa ===="
+echo "---- PostgreSQL ---- "
+echo ">> Usuário: odoo -- Senha: 123"
+echo ">> Usuário: postgres -- Senha = 123"
+echo "---- Instância Odoo ----"
+echo "Pasta de instalação: ~/odoo"
+echo "Pasta de Addons: addons, ~/odoo/addons, ~/odoo-brasil"
+echo "========================================================"
+echo "A instalação está completa !"
+echo "Obrigado por usar este script !!!"


### PR DESCRIPTION
O foco inicial deste commit é adicionar a instalação de dois pacotes dos repositórios do Ubuntu que são necessários para a construção e instalação da dependência Python, o Pillow.
O mesmo requer no sistema o pacote `python-dev` e o `gcc`.

Tão como já embutido no código o download do **deb**   do _wkhtmltox_.


---
_Nota: E aproveitando, já reorganizei as informações jogadas na tela do usuário, mantendo ao final da instalação informações importantes sobre a configuração feita._