### PR TITLE
Adicionando pip install wheel

### DIFF
--- a/install_odoo_trustcodebr.sh
+++ b/install_odoo_trustcodebr.sh
@@ -117,6 +117,7 @@ sudo -H pip install suds_requests
 sudo -H pip install pytrustnfe
 sudo -H pip install python-boleto
 sudo -H pip install python-cnab
+sudo -H pip install wheel
 sudo -H pip install http://labs.libre-entreprise.org/frs/download.php/897/pyxmlsec-0.3.1.tar.gz
 echo ">>> pip e seus requerimentos estão instalados. <<<"
 


### PR DESCRIPTION
A instalação do pyxmlsec-0.3.1 estava falhando por falta do Wheel. Acabei de adicioná-lo para resgardar casos iguais a este (onde o usuário não possui o wheel instalado).